### PR TITLE
Make the W3C Markup Validator happy

### DIFF
--- a/source/_web-template/web-template.html
+++ b/source/_web-template/web-template.html
@@ -399,7 +399,7 @@ Kobayashi Issa
 <div id="bookmark">
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 40 80" xml:space="preserve">
   <g>
-    <polygon points="0,0 0,80 20,70 40,80 40,0"
+    <polygon points="0,0 0,80 20,70 40,80 40,0"/>
   </g>
 </svg>
 </div>

--- a/source/_web-template/web-template.html
+++ b/source/_web-template/web-template.html
@@ -11,7 +11,7 @@ Kobayashi Issa
 -->
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0, user-scalable=0.0" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/source/_web-template/web-template.html
+++ b/source/_web-template/web-template.html
@@ -391,7 +391,7 @@ Kobayashi Issa
   <p>Basically, <small>everything works</small></p>
 </div>
 
-<img class="cover" src="{{ cover_image }}" />
+<img class="cover" src="{{ cover_image }}" alt="" />
 {{ title_html }}
 {{ web_book_body_html }}
 <p class="last-page"></p>

--- a/source/annabel-scheme-new-golden-gate.md
+++ b/source/annabel-scheme-new-golden-gate.md
@@ -1078,4 +1078,4 @@ This e-book's cover uses Bild Compressed, designed by David Jonathan Ross and of
 
 The cover also features two public domain photographs. One is an image of [the Bay Bridge being built](https://www.baybridgeinfo.org/sites/default/files/images_bulk/I0035219A.jpg) in 1936. The other is [Arnold Genthe's photograph](https://www.artic.edu/artworks/65808/san-francisco-earthquake) of the San Francisco earthquake and fire in 1906. The original is presented on the next page.
 
-<img src="img/genthe-fire.png" />
+<img src="img/genthe-fire.png" alt="" />


### PR DESCRIPTION
This pull request aims to resolve some of the errors and warnings that show up when [validating the generated HTML](https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.robinsloan.com%2Fbooks%2Fannabel-scheme-serial%2Fread%2F) using W3C's Nu Html Checker. Even if this pull request is merged, one type of error and one warning persists:

<img src="https://user-images.githubusercontent.com/35639/87483242-8e39b600-c633-11ea-90cb-74a413c30c59.png" alt="" width="444" />

The warning against multiple `<h1>` elements is a matter of taste. The Table of Contents could be marked up using `<h2>` instead, maybe?

~~The stray end tag for `<wbr>` error is, from what I can tell, [caused by nokogiri](https://github.com/sparklemotion/nokogiri/issues/1044).~~

PS. The `<wbr>` error is now gone thanks to a change in https://github.com/robinsloan/perfect-edition/commit/e8ea44e4f5a29b452bd61bd2e1deefd46cd1a4a6.