### PR TITLE
Create default css for Edge Chromium on Andriod and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore Gemfile.lock
+Gemfile.lock
+
+# Ignore build folder
+build

--- a/source/css/web.css
+++ b/source/css/web.css
@@ -34,7 +34,21 @@
 }
 
 :root {
-  --base-unit: clamp(28px, 5vh, 56px); /* used to be vw, but vh works better */
+  /* Baseline defaults for all devices */
+  --base-unit: 5vh;
+  --column-width: 50vw;
+}
+
+@supports (width: clamp(28px, 5vh, 56px)) {
+  :root {
+    /* Baseline defaults for all devices and browsers that support clamp() */
+    /* Edge Chromium on Android has an issue with supporting clamp() for widths */
+    --base-unit: clamp(28px, 5vh, 56px);
+    --column-width: clamp(480px, 50vw, 640px);
+  }
+}
+
+:root {
   --base-unit-half: calc( var(--base-unit) / 2.0 );
 
   --font-size: var(--base-unit-half);
@@ -43,7 +57,6 @@
 
   --vertical-padding: var(--base-unit);
 
-  --column-width: clamp(480px, 50vw, 640px);
     /* this 4.0 is a bit cryptic; we are making space for the toc button:; */
   --column-height: calc(100vh - calc(var(--vertical-padding) * 4.0));
   --column-gap: var(--base-unit);


### PR DESCRIPTION
Two issue PR (sorry for the double issue).

**Edge Chromium on Android has either an unsupported or buggy rendering of clamp().** 
Before:
![image](https://user-images.githubusercontent.com/10966357/87707525-1b752b80-c756-11ea-9e81-b854fc3a37ba.png)
![image](https://user-images.githubusercontent.com/10966357/87707535-1f08b280-c756-11ea-9da3-51c17c197229.png)
After: 
![image](https://user-images.githubusercontent.com/10966357/87707643-4d868d80-c756-11ea-8015-0c8f45fab36f.png)
![image](https://user-images.githubusercontent.com/10966357/87707647-50817e00-c756-11ea-904c-f8d5d75da360.png)

This shouldn't impact any other browsers but will get things functional on Edge Chromium on Android.

**Missing .gitignore file**
- Added a .gitignore file to ignore any pushes of the build folder to the repository, this should avoid the possibility of having conflicts in the build folder. 
- Added Gemlock.file to avoid pushes of the lock file this should avoid system specific errors.
