### PR TITLE
Unique chapters

### DIFF
--- a/generate.rb
+++ b/generate.rb
@@ -98,14 +98,14 @@ toc_items = []
 book.css("h2").each do |heading|
   # This is a version of the title suitable for use in an anchor tag:
   href_title = heading.inner_html.gsub(/\W/, "_").downcase
-  
+
   # If the href has already been seen, add a count to the end
-  if toc_items.collect { |item| item[:href_title] }.include? href_title                                               
-    dups = toc_items.find_all do |item|                                                                               
-      item[:href_title].start_with? href_title 
-    end                                                                                                               
+  if toc_items.collect { |item| item[:href_title] }.include? href_title
+    dups = toc_items.find_all do |item|
+      item[:href_title].start_with? href_title
+    end
     href_title = "#{href_title}-#{dups.length}"
-  end 
+  end
 
   toc_items << {:title => heading.inner_html, :href_title => href_title}
 

--- a/generate.rb
+++ b/generate.rb
@@ -98,6 +98,14 @@ toc_items = []
 book.css("h2").each do |heading|
   # This is a version of the title suitable for use in an anchor tag:
   href_title = heading.inner_html.gsub(/\W/, "_").downcase
+  
+  # If the href has already been seen, add a count to the end
+  if toc_items.collect { |item| item[:href_title] }.include? href_title                                               
+    dups = toc_items.find_all do |item|                                                                               
+      item[:href_title].start_with? href_title 
+    end                                                                                                               
+    href_title = "#{href_title}-#{dups.length}"
+  end 
 
   toc_items << {:title => heading.inner_html, :href_title => href_title}
 


### PR DESCRIPTION
I've got a project that uses several chapters titled after the character, which means several chapters named the same thing. This just prepends `chapter_num` to chapter IDs if it's requested in `book.yaml`