### PR TITLE
Add a cross button inside TOC

### DIFF
--- a/source/_web-template/web-template.html
+++ b/source/_web-template/web-template.html
@@ -241,6 +241,13 @@ Kobayashi Issa
       e.stopPropagation();
     });
 
+    // cross button
+
+    document.querySelector(".cross-button").addEventListener("click", e => {
+      toggleNav();
+      e.stopPropagation();
+    });
+
     // toc text size buttons
 
     document.querySelectorAll("nav div.controls button").forEach(button => {
@@ -373,6 +380,7 @@ Kobayashi Issa
 
 <div class="toc">
 <h1>Table of Contents</h1>
+<span class="cross-button">˟</span>
 {{ web_toc_html }}
 </div>
 </nav>

--- a/source/css/web.css
+++ b/source/css/web.css
@@ -186,6 +186,18 @@ nav div.toc {
 
   overflow-x: hidden;
   overflow-y: scroll;
+  position: relative;
+}
+
+nav span.cross-button {
+  position: absolute;
+  right: 0.5rem;
+  top: 1.25rem;
+  font-size: 2rem;
+}
+
+nav span.cross-button:hover {
+  cursor: pointer;
 }
 
 nav div.controls {


### PR DESCRIPTION
Just a small usability improvement by adding an explicit cross button in the TOC.

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/2495633/87777923-a7f11e00-c82a-11ea-9085-e7d1dcebdf74.png">