### PR TITLE
Add dark mode to web

### DIFF
--- a/source/css/web.css
+++ b/source/css/web.css
@@ -77,6 +77,14 @@
   --page-count: 1;
 }
 
+@media(prefers-color-scheme:dark) {
+  :root {
+    --paper-lightness: 1%;
+    --selection-color: hsla(340, 100%, 25%, 1.0);
+    --text-color: rgb(250, 250, 250);
+  }
+}
+
 ::-moz-selection { background: var(--selection-color); }
 ::selection { background: var(--selection-color); }
 
@@ -160,15 +168,17 @@ button.toc-button {
 
   border: 1px solid var(--text-color);
   background-color: var(--paper-color);
+  color: inherit;
   transform: translateX(-50%) translateY(-50%);
 }
 
 button.toc-button:hover {
   border: 1px solid var(--spot-color);
-  fill: var(--spot-color);
+  color: var(--spot-color);
 }
 
 button.toc-button svg {
+  fill: currentColor;
   flex-grow: 1;
 }
 


### PR DESCRIPTION
<img width="300" alt="Screenshot of web book in dark mode on mobile" src="https://user-images.githubusercontent.com/486540/87898736-47213b80-ca0c-11ea-8a03-6ccee646cfa1.png">

- Automatically applies based on system appearance
- Inverts all relevant colors
    - `--spot-color` remains the same
- Minimal additional changes to make it work

### Notes

There's a small issue with the scrollbar styles when the viewport is wide enough to show the shades on the left/right:

<img width="500" alt="Screenshot of web book in dark mode on desktop" src="https://user-images.githubusercontent.com/486540/87898807-733cbc80-ca0c-11ea-9984-82e784abe564.png">

I'm the weird one with the non-default setting to show scrollbars all the time, so I doubt this is much of a problem for most.

### Follow-up

It's fairly common to offer a manual toggle in addition to this automatic switch for dark mode. Let me know if you think that fits with the minimal ethos of the project.
