### PR TITLE
Add scrim behind nav menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ ruby serve.rb
 That will
 
 1. combine the text with the template to generate a finished e-book in a new `build` directory, and
-2. serve that finished e-book, which you can view at `http://localhost:8000/web-book.html`.
+2. serve that finished e-book, which you can view at `http://localhost:8000/`.
 
 (The script also generates an EPUB edition, which really isn't the focus of this project, but a feature I needed, so there you go!)
 

--- a/source/_web-template/web-template.html
+++ b/source/_web-template/web-template.html
@@ -278,8 +278,8 @@ Kobayashi Issa
     });
 
     // scrim behind nav
-    document.querySelector("nav").addEventListener("click", e => {
-      if (e.target.nodeName.toUpperCase() !== "NAV" ) {
+    navElement.addEventListener("click", e => {
+      if (e.target.nodeName.toUpperCase() !== navElement.nodeName.toUpperCase()) {
         return; // clicked a child, not the scrim
       }
       toggleNav();

--- a/source/_web-template/web-template.html
+++ b/source/_web-template/web-template.html
@@ -266,22 +266,29 @@ Kobayashi Issa
     }
 
     // toc button
-
     document.querySelector("button.toc-button").addEventListener("click", e => {
       toggleNav();
       e.stopPropagation();
     });
 
     // cross button
-
     document.querySelector("div.close-button").addEventListener("click", e => {
+      toggleNav();
+      e.stopPropagation();
+    });
+
+    // scrim behind nav
+    document.querySelector("nav").addEventListener("click", e => {
+      if (e.target.nodeName.toUpperCase() !== "NAV" ) {
+        return; // clicked a child, not the scrim
+      }
       toggleNav();
       e.stopPropagation();
     });
 
     // toc text size buttons
 
-    document.querySelectorAll("nav div.controls button").forEach(button => {
+    document.querySelectorAll("#nav-contents div.controls button").forEach(button => {
       let size = `${baseFontSize * button.dataset.scale}px`;
       button.style.fontSize = size;
 
@@ -300,7 +307,7 @@ Kobayashi Issa
                                 .replace("px", "") );
       console.log(`real font size detected: ${realFontSize}px`);
 
-      document.querySelectorAll("nav div.controls button").forEach(button => {
+      document.querySelectorAll("#nav-contents div.controls button").forEach(button => {
         let size = `${realFontSize * button.dataset.scale}px`;
         button.style.fontSize = size;
 
@@ -367,6 +374,11 @@ Kobayashi Issa
       return;
     }
 
+    // don't advance if nav is visible
+    if (navElement.className == "visible") {
+      return;
+    }
+
     lastClick = now;
 
     // don't advance on link click
@@ -401,6 +413,7 @@ Kobayashi Issa
 <body>
 
 <nav class="invisible">
+<div id="nav-contents">
 <div class="controls">
   <button data-scale="0.8">A</button>
   <button data-scale="1.0">A</button>
@@ -420,6 +433,7 @@ Kobayashi Issa
 </svg>
 </div>
 {{ web_toc_html }}
+</div>
 </div>
 </nav>
 

--- a/source/css/web.css
+++ b/source/css/web.css
@@ -185,11 +185,31 @@ button.toc-button svg {
 nav {
   position: fixed;
 
+  top: 0;
+  left: 0;
+
+  z-index: 10000;
+  width: 100%;
+  height: 100%;
+
+  background-color: hsla(var(--paper-hue), calc(var(--paper-saturation) * 2.0), var(--paper-lightness), 0.7);
+
+  overflow-x: hidden;
+  overflow-y: hidden;
+
+  text-align: left;
+
+  transition: opacity 0.1s;
+}
+
+nav #nav-contents {
+  position: fixed;
+
   top: calc( var(--vertical-padding) + var(--base-unit) );
   /* the toc is 90% of the page's width */
   left: calc( 50vw - var(--column-width) * 0.45);
 
-  z-index: 10000;
+  z-index: 10001;
   /* this is all a little bit stupid and I'm sure there's a more
   principled way to do it */
   width: calc( var(--column-width) * 0.9 );
@@ -219,7 +239,7 @@ nav.invisible {
   pointer-events: none;
 }
 
-nav div.toc {
+#nav-contents div.toc {
   width: calc( var(--column-width) * 0.9 );
   height: calc( var(--column-height) - var(--base-unit) * 2.0 );
 
@@ -230,7 +250,7 @@ nav div.toc {
   position: relative;
 }
 
-nav div.close-button {
+#nav-contents div.close-button {
   position: fixed;
   top: calc( var(--vertical-padding) + var(--base-unit) + var(--base-unit));
   right: calc( 50vw + var(--base-unit) - var(--column-width) * 0.45);
@@ -240,11 +260,11 @@ nav div.close-button {
   stroke-width: 1px;
 }
 
-nav div.close-button:hover {
+#nav-contents div.close-button:hover {
   cursor: pointer;
 }
 
-nav div.controls {
+#nav-contents div.controls {
   display: flex;
   position: fixed;
 
@@ -268,7 +288,7 @@ nav div.controls {
   z-index: 100000;
 }
 
-nav div.controls button {
+#nav-contents div.controls button {
   flex-shrink: 0;
 
   margin: 0 var(--base-unit-half) 0 0;
@@ -284,15 +304,15 @@ nav div.controls button {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-nav div.controls button:last-child {
+#nav-contents div.controls button:last-child {
   margin: 0 0 0 0;
 }
 
-nav div.controls button:hover {
+#nav-contents div.controls button:hover {
   color: var(--text-color);
 }
 
-nav h1 {
+#nav-contents h1 {
   margin: 0 0 var(--line-height) 0;
   width: calc( var(--column-width) * 0.9 - calc( var(--base-unit) * 2.0 ) );
   padding: 0;
@@ -303,7 +323,7 @@ nav h1 {
   font-weight: 400;
 }
 
-nav ol {
+#nav-contents ol {
   margin: 0;
   width: 90%;
   padding: 0;
@@ -311,13 +331,13 @@ nav ol {
   margin-bottom: var(--line-height);
 }
 
-nav ol li {
+#nav-contents ol li {
   margin: 0 0 var(--line-height) 0;
   line-height: var(--line-height);
   font-size: 1rem;
 }
 
-nav ol li:last-of-type {
+#nav-contents ol li:last-of-type {
   margin: 0 0 0 0;
 }
 


### PR DESCRIPTION
This way, the "tap outside" pattern works to dismiss the nav, and it's less likely that someone switches pages by mistake while the nav is open. Tested in Chrome/Firefox/Safari.

Also happy to wait or rework if https://github.com/robinsloan/perfect-edition/issues/5 should land first!

<details>
<summary>Demo gif</summary>
Gif showing: opening nav menu, navigating to a chapter as normal, reopening menu, tapping outside menu to close.

![2020-07-24 12 35 47](https://user-images.githubusercontent.com/99264/88414061-41c84600-cdaa-11ea-98b3-8dfe617ca4ee.gif)
</details>